### PR TITLE
simplify docker build script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,6 @@
 FROM golang:alpine as builder
-
-WORKDIR /go/src/
-
-RUN mkdir -p github.com/mehrdadrad/tcpprobe
-COPY . github.com/mehrdadrad/tcpprobe
-
 WORKDIR /go/src/github.com/mehrdadrad/tcpprobe
-
+COPY . .
 RUN CGO_ENABLED=0 go build
 
 FROM alpine 


### PR DESCRIPTION
Hi mehrdadrad:

1. we can simplify image build script, as the [docker documentation](https://docs.docker.com/engine/reference/builder/#workdir) says: If the WORKDIR doesn’t exist, it will be created, so we can just use `WORKDIR /go/src/github.com/mehrdadrad/tcpprobe
` replace multiple lines, and then copy current dir to the container

2. I test this on my laptop, it works fine
```sh
docker build -t  mehrdadrad/tcpprobe:v0.2  .
...........                                                                                                                                                  
 ---> b870df39c040
Step 6/9 : FROM alpine
 ---> d6e46aa2470d
Step 7/9 : COPY --from=builder /go/src/github.com/mehrdadrad/tcpprobe/tcpprobe /usr/bin/
 ---> Using cache
 ---> c33729cb2037
Step 8/9 : EXPOSE 8081
 ---> Using cache
 ---> 2658e857863b
Step 9/9 : ENTRYPOINT ["tcpprobe"]
 ---> Using cache
 ---> 2440e7304aff
Successfully built 2440e7304aff
Successfully tagged mehrdadrad/tcpprobe:v0.2
```

```sh
docker container run --rm mehrdadrad/tcpprobe:v0.2 https://cn.bing.com                                                                                                                                                                     
Target:https://cn.bing.com IP:202.89.233.100 Timestamp:1607011996
State:1 CaState:0 Retransmits:0 Probes:0 Backoff:0 Options:6 Rto:230000 Ato:40000 SndMss:1412 RcvMss:1412 Unacked:0 Sacked:0 Lost:0 Retrans:0 Fackets:0 LastDataSent:130 LastAckSent:0 LastDataRecv:0 LastAckRecv:4 Pmtu:1500 RcvSsthresh:64076 Rtt:27506 Rttvar:6368 SndSsthresh:2147483647 SndCwnd:10 Advmss:1460 Reordering:3 RcvRtt:0 RcvSpace:14600 TotalRetrans:0 HTTPStatusCode:200 HTTPRcvdBytes:112920 HTTPRequest:229663 HTTPResponse:32820 DNSResolve:27775 TCPConnect:27406 TLSHandshake:131382 TCPConnectError:0 DNSResolveError:0 
```







